### PR TITLE
Enable debug and exit on disconnection

### DIFF
--- a/localbot/Program.cs
+++ b/localbot/Program.cs
@@ -24,6 +24,7 @@ namespace localbot
             {
                 var client = services.GetRequiredService<DiscordSocketClient>();
                 client.Log += LogAsync;
+                client.Disconnected += Disconnected;
                 services.GetRequiredService<CommandService>().Log += LogAsync;
                 await client.LoginAsync(TokenType.Bot, token);
                 await client.StartAsync();
@@ -39,6 +40,13 @@ namespace localbot
         {
             Console.WriteLine(log.ToString());
 
+            return Task.CompletedTask;
+        }
+        
+        private Task Disconnected(Exception e)
+        {
+            Console.WriteLine("Closing because of disconnection. Exception: " + e.ToString());
+            Environment.Exit(1);
             return Task.CompletedTask;
         }
 

--- a/localbot/Program.cs
+++ b/localbot/Program.cs
@@ -44,8 +44,12 @@ namespace localbot
 
         private ServiceProvider ConfigureServices()
         {
+            var config = new DiscordSocketConfig
+            {
+                LogLevel = LogSeverity.Debug
+            };
             return new ServiceCollection()
-                .AddSingleton<DiscordSocketClient>()
+                .AddSingleton<DiscordSocketClient>(new DiscordSocketClient(config))
                 .AddSingleton<CommandService>()
                 .AddSingleton<CommandHandlingService>()
                 .AddSingleton<PinService>()


### PR DESCRIPTION
The bot has been disconnecting and failing to reconnect with the message "Server missed last heartbeat". Unfortunately this bug cannot be reproduced and only happens after continuously running the bot for a long time. This PR:

- Enables debug messages to assist in isolating the issue
- Exits the program if the bot ever disconnects in order to avoid reconnection problems (it is possible the error is in the disconnection process, in which case this may fail)

If the program does exit on disconnection, it must be restarted on a higher level. [Running it as a service](https://docs.microsoft.com/en-us/dotnet/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer) may be helpful (though I do not know much about this).

These problems seem to be due to an underlying issue with the Discord.Net library: see https://github.com/discord-net/Discord.Net/issues/960